### PR TITLE
Add streaming support

### DIFF
--- a/command.go
+++ b/command.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/joshcarp/grpctl/internal/grpc"
-	"google.golang.org/grpc/metadata"
 	"io"
 	"strings"
+
+	"github.com/joshcarp/grpctl/internal/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/proto"
@@ -230,9 +231,9 @@ func handleUnary(cmd *cobra.Command, addr string, method protoreflect.MethodDesc
 }
 
 func handleStreaming(cmd *cobra.Command, method protoreflect.MethodDescriptor, addr, protocol string, http1 bool) (err error) {
-	inputJson, outputJson := make(chan []byte), make(chan []byte)
+	inputJSON, outputJSON := make(chan []byte), make(chan []byte)
 	go func() {
-		reterr := grpc.CallStreaming(cmd.Root().Context(), addr, method, protocol, http1, inputJson, outputJson)
+		reterr := grpc.CallStreaming(cmd.Root().Context(), addr, method, protocol, http1, inputJSON, outputJSON)
 		if reterr != nil {
 			err = reterr
 			return
@@ -251,10 +252,10 @@ func handleStreaming(cmd *cobra.Command, method protoreflect.MethodDescriptor, a
 		if err != nil {
 			return err
 		}
-		inputJson <- byteMsg
+		inputJSON <- byteMsg
 	}
-	close(inputJson)
-	for marshallerm := range outputJson {
+	close(inputJSON)
+	for marshallerm := range outputJSON {
 		res := string(marshallerm)
 		if err != nil {
 			_, err = cmd.OutOrStderr().Write([]byte(err.Error()))
@@ -264,7 +265,9 @@ func handleStreaming(cmd *cobra.Command, method protoreflect.MethodDescriptor, a
 			return err
 		}
 		_, err = cmd.OutOrStdout().Write([]byte(res))
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/command_test.go
+++ b/command_test.go
@@ -126,7 +126,7 @@ help	Help about any command
 					WithReflection(args),
 				}
 			},
-			want: `ListBars	ListBars as defined in api.proto
+			want: `ListBars	ListBars (Unary) as defined in api.proto
 :4
 `,
 		},

--- a/command_test.go
+++ b/command_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"testing"
 
 	"google.golang.org/genproto/googleapis/api/annotations"
@@ -52,6 +53,23 @@ func TestBuildCommand(t *testing.T) {
 				return []CommandOption{
 					WithArgs(args),
 					WithReflection(args),
+				}
+			},
+			json: fmt.Sprintf("{\n \"message\": \"Incoming Message: blah \\n "+
+				"Metadata: map[:authority:[%s] accept-encoding:[identity] "+
+				"content-type:[application/grpc+proto] grpc-accept-encoding:[gzip] "+
+				"user-agent:[grpc-go-connect/1.1.0 (%s)]]\"\n}", addr, runtime.Version()),
+		},
+		{
+			name: "streaming",
+			args: []string{
+				"grpctl", "--address=http://localhost:8081", "ElizaService", "Rant", "--protocol=grpc",
+			},
+			opts: func(args []string) []CommandOption {
+				return []CommandOption{
+					WithArgs(args),
+					WithReflection(args),
+					WithStdin(strings.NewReader(`[{"sentence": "foobar"}, {"sentence": "foobar"}]`)),
 				}
 			},
 			json: fmt.Sprintf("{\n \"message\": \"Incoming Message: blah \\n "+

--- a/command_test.go
+++ b/command_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"strings"
 	"testing"
 
 	"google.golang.org/genproto/googleapis/api/annotations"
@@ -61,23 +60,6 @@ func TestBuildCommand(t *testing.T) {
 				"user-agent:[grpc-go-connect/1.1.0 (%s)]]\"\n}", addr, runtime.Version()),
 		},
 		{
-			name: "streaming",
-			args: []string{
-				"grpctl", "--address=http://localhost:8081", "ElizaService", "Rant", "--protocol=grpc",
-			},
-			opts: func(args []string) []CommandOption {
-				return []CommandOption{
-					WithArgs(args),
-					WithReflection(args),
-					WithStdin(strings.NewReader(`[{"sentence": "foobar"}, {"sentence": "foobar"}]`)),
-				}
-			},
-			json: fmt.Sprintf("{\n \"message\": \"Incoming Message: blah \\n "+
-				"Metadata: map[:authority:[%s] accept-encoding:[identity] "+
-				"content-type:[application/grpc+proto] grpc-accept-encoding:[gzip] "+
-				"user-agent:[grpc-go-connect/1.1.0 (%s)]]\"\n}", addr, runtime.Version()),
-		},
-		{
 			name: "completion_enabled",
 			args: []string{
 				"root",
@@ -117,6 +99,7 @@ Use "root [command] --help" for more information about a command.
 			},
 			want: `BarAPI	BarAPI as defined in api.proto
 FooAPI	FooAPI as defined in api.proto
+ServerReflection	ServerReflection as defined in reflection/grpc_reflection_v1alpha/reflection.proto
 completion	Generate the autocompletion script for the specified shell
 help	Help about any command
 :4

--- a/internal/grpc/connect.go
+++ b/internal/grpc/connect.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-
 	"github.com/bufbuild/connect-go"
 	"github.com/joshcarp/grpctl/internal/descriptors"
 	"google.golang.org/grpc/metadata"
@@ -65,4 +64,138 @@ func CallUnary(ctx context.Context, addr string, method protoreflect.MethodDescr
 		return nil, err
 	}
 	return protojson.MarshalOptions{Resolver: &registry, Multiline: true, Indent: " "}.Marshal(dynamicResponse)
+}
+
+func ParseMessage(inputJson []byte, messageDesc protoreflect.MessageDescriptor) (*emptypb.Empty, error) {
+	dynamicRequest := dynamicpb.NewMessage(messageDesc)
+	err := protojson.Unmarshal(inputJson, dynamicRequest)
+	if err != nil {
+		return nil, err
+	}
+	requestBytes, err := proto.Marshal(dynamicRequest)
+	if err != nil {
+		return nil, err
+	}
+	request := &emptypb.Empty{}
+	if err := proto.Unmarshal(requestBytes, request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func Send(inputJson chan []byte, messageDescriptor protoreflect.MessageDescriptor, f func(*emptypb.Empty) error) error {
+	for inputs := range inputJson {
+		request, err := ParseMessage(inputs, messageDescriptor)
+		if err != nil {
+			return err
+		}
+		err = f(request)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Receive(outputJson chan []byte, method protoreflect.MethodDescriptor, f func() (*emptypb.Empty, error)) error {
+	defer close(outputJson)
+	for {
+		msg, err := f()
+		if err != nil {
+			return err
+		}
+		if msg == nil {
+			break
+		}
+		responseBytes, err := proto.Marshal(msg)
+		if err != nil {
+			return nil
+		}
+		dynamicResponse := dynamicpb.NewMessage(method.Output())
+		if err := proto.Unmarshal(responseBytes, dynamicResponse); err != nil {
+			return err
+		}
+		reg, err := registry(method)
+		if err != nil {
+			return err
+		}
+		b, err := protojson.MarshalOptions{Resolver: &reg, Multiline: true, Indent: " "}.Marshal(dynamicResponse)
+		if err != nil {
+			return err
+		}
+		outputJson <- b
+	}
+	return nil
+}
+
+func CallStreaming(ctx context.Context, addr string, method protoreflect.MethodDescriptor, protocol string, http1 bool, inputJson, outputJson chan []byte) error {
+	client := getClient(addr, method, protocol, http1)
+	if method.IsStreamingClient() && method.IsStreamingServer() {
+		stream := client.CallBidiStream(ctx)
+		if err := Send(inputJson, method.Input(), stream.Send); err != nil {
+			return err
+		}
+		if err := Receive(outputJson, method, stream.Receive); err != nil {
+			return err
+		}
+	} else if method.IsStreamingClient() {
+		stream := client.CallClientStream(ctx)
+		if err := Send(inputJson, method.Input(), stream.Send); err != nil {
+			return err
+		}
+		err := Receive(outputJson, method, func() (*emptypb.Empty, error) {
+			resp, err := stream.CloseAndReceive()
+			if err != nil {
+				return nil, err
+			}
+			return resp.Msg, err
+		})
+		if err != nil {
+			return err
+		}
+	} else if method.IsStreamingServer() {
+		req, err := ParseMessage(<-inputJson, method.Input())
+		if err != nil {
+			return err
+		}
+		stream, err := client.CallServerStream(ctx, connect.NewRequest(req))
+		if err != nil {
+			return err
+		}
+		err = Receive(outputJson, method, func() (*emptypb.Empty, error) {
+			if stream.Receive() {
+				return stream.Msg(), nil
+			}
+			return nil, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func registry(method protoreflect.MethodDescriptor) (protoregistry.Types, error) {
+	var registry protoregistry.Types
+	if err := registry.RegisterMessage(dynamicpb.NewMessageType(method.Output())); err != nil {
+		return protoregistry.Types{}, err
+	}
+	if err := registry.RegisterMessage(dynamicpb.NewMessageType(method.Input())); err != nil {
+		return protoregistry.Types{}, err
+	}
+	return registry, nil
+}
+
+func getClient(addr string, method protoreflect.MethodDescriptor, protocol string, http1 bool) *connect.Client[emptypb.Empty, emptypb.Empty] {
+	fqnAddr := addr + descriptors.FullMethod(method)
+	var clientOpts []connect.ClientOption
+	switch protocol {
+	case "grpc":
+		clientOpts = append(clientOpts, connect.WithGRPC())
+	case "grpcweb":
+		clientOpts = append(clientOpts, connect.WithGRPCWeb())
+	case "connect":
+	default:
+	}
+	return connect.NewClient[emptypb.Empty, emptypb.Empty](client(http1), fqnAddr, clientOpts...)
 }


### PR DESCRIPTION
Adds support for all streamings. This will be able to take a simple json array of objects to pipe into `Send` and `Receive` will print out the response all at once. 

In the future it would be good to have a better ux by having a more interactive terminal like the rest of grpctl